### PR TITLE
test16 fix and able to use larger client buffer

### DIFF
--- a/.github/workflows/bufsize-512.yml
+++ b/.github/workflows/bufsize-512.yml
@@ -1,0 +1,46 @@
+name: coveralls
+
+on: [push, pull_request]
+
+env:
+  ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS: http://arduino.esp8266.com/stable/package_esp8266com_index.json
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.0
+
+      - name: Install Packages
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y gcc-multilib lcov
+
+      - name: Configure CMake
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCOVERALLS=ON -DCMAKE_CXX_FLAGS="-DWEBSERVER_BUFFER_SIZE=512"
+          cd ..
+
+      - name: Build
+        run: |
+          cd build
+          make -j4
+          ./start
+          cd ..
+
+      - name: Coveralls
+        run: |
+          cd build
+          gem install coveralls-lcov
+          lcov -c -d CMakeFiles/start.dir -o coverage.info
+          lcov -r coverage.info '/usr/include/*' '*main.cpp' -o coverage-filtered.info
+          lcov --list coverage-filtered.info
+          genhtml coverage-filtered.info
+          coveralls-lcov --repo-token ${{ secrets.COVERALLS }} coverage.info

--- a/main.cpp
+++ b/main.cpp
@@ -1187,6 +1187,46 @@ struct unittest_t {
         "\r\n"
       }
     }
+  },
+  {
+    "POST",
+    "/",
+    "HTTP/1.1",
+    "----WebKitFormBoundaryr33oB2ai8vKFc8V1",
+    1,
+    11,
+    {
+      { "Host", "heishamonrulestest.local" },
+      { "User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36" },
+      { "Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7" },
+      { "Accept-Language", "en-US,en;q=0.9,nl-NL;q=0.8,nl;q=0.7,de;q=0.6" },
+      { "Accept-Encoding", "gzip, deflate" },
+      { "Content-Type", "multipart/form-data; boundary=----WebKitFormBoundaryr33oB2ai8vKFc8V1" },
+      { "Content-Length", "499" },
+      { "Cache-Control", "max-age=0" },
+      { "Connection", "keep-alive" },
+      { "Origin", "http://heishamonrulestest.local" },
+      { "Referer", "http://heishamonrulestest.local/rules" },
+      { "Upgrade-Insecure-Requests", "1" }
+    },
+    1,
+    {
+      { 0, "rules",
+        "on System#Boot then\r\n"
+        "settimer(1,10);\r\n"
+        "emd\r\n"
+        "\r\n"
+        "on timer=1 then\r\n"
+        "  settimer(1,10);\r\n"
+        "\r\n"
+        "  @SetCurves = concat('{zone1:{heat:{target:{high:', 35, '}}}}');\r\n"
+        "  print(concat('PrintTest = {zone1:{heat:{target:{high:', 35, '}}}}'));\r\n"
+        "  #globalTest = concat('{zone1:{heat:{target:{high:', 35, '}}}}');\r\n"
+        "  $localTest = concat('{zone1:{heat:{target:{high:', 35, '}}}}');\r\n"
+        "\r\n"
+        "end"
+      }
+    }
   }
 };
 

--- a/strnstr.cpp
+++ b/strnstr.cpp
@@ -18,7 +18,7 @@ unsigned char *strnstr(unsigned char *str1, const char *str2, uint16_t size) {
     if(ch == str2[0] && a+len <= size) {
       c = a;
       a++;
-      for(b=1;b<=len;a++, b++) {
+      for(b=1;b<len;a++, b++) {
         ch = str1[a];
         if(str2[b] != ch) {
           break;

--- a/webserver.cpp
+++ b/webserver.cpp
@@ -62,8 +62,6 @@
 
 void log_message(char *string);
 
-bool ending3dash = false;
-
 struct webserver_client_t clients[WEBSERVER_MAX_CLIENTS];
 #ifdef ESP8266
 static tcp_pcb *async_server = NULL;


### PR DESCRIPTION
This PR adds test16 which fails on previous build due to a split \r\n-- delimiter on end of buffer.
The 2nd commit fixes this test16 and also fixes the issue when making the client buffer larger than the default of 128 bytes.
It also fixes an issue with strnstr in the strnctr.cpp when the string to find is on the end of the buffer