### PR TITLE
change order of header fix case 4

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1587,8 +1587,8 @@ void test_receive(void) {
             if(unittest[testnr].args[z].type == 0) {
               len += sprintf(&out[len], "Content-Disposition: form-data; name=\"%s\"\r\n", unittest[testnr].args[z].name);
             } else if(unittest[testnr].args[z].type == 1) {
-              len += sprintf(&out[len], "Content-Disposition: form-data; name=\"%s\"; filename=\"%s.txt\"\r\n", unittest[testnr].args[z].name, unittest[testnr].args[z].name);
               len += sprintf(&out[len], "Content-Type: text/plain\r\n");
+              len += sprintf(&out[len], "Content-Disposition: form-data; name=\"%s\"; filename=\"%s.txt\"\r\n", unittest[testnr].args[z].name, unittest[testnr].args[z].name);
             }
             len += sprintf(&out[len], "\r\n");
             len += sprintf(&out[len], "%s\r\n", unittest[testnr].args[z].value);

--- a/webserver.cpp
+++ b/webserver.cpp
@@ -921,26 +921,46 @@ int http_parse_multipart_body(struct webserver_t *client, unsigned char *buf, ui
           }
         } break;
         // Filename etc.
-        case 4: {
-          unsigned char *ptr = strncasestr(client->buffer, "\";", client->ptr);
-          if(ptr != NULL) {
+	case 4: {
+    	  unsigned char *ptr = strncasestr(client->buffer, "\";", client->ptr);
+    	  if(ptr != NULL) {
             uint16_t pos = (ptr-client->buffer);
-            unsigned char *ptr1 = strncasestr(&client->buffer[pos], "\r\n", client->ptr-pos);
+            // First try to find \r\n\r\n (end of all headers)
+            unsigned char *ptr1 = strnstr(&client->buffer[pos], "\r\n\r\n", client->ptr-pos);
             if(ptr1 != NULL) {
+              // Double CRLF found - skip directly to data
+	      //printf("double CRLF\n");
               client->buffer[pos++] = '=';
               uint16_t pos1 = (ptr1-client->buffer);
-              uint16_t newlen = client->ptr-((pos1+2)-pos);
-              memmove(&client->buffer[pos], &client->buffer[pos1+2], newlen);
+              uint16_t newlen = client->ptr-((pos1+4)-pos);
+              memmove(&client->buffer[pos], &client->buffer[pos1+4], newlen);
               client->ptr = newlen;
-              client->readlen += (pos1+2);
-              client->substep = 5;
+              client->readlen += (pos1+4);
+              client->substep = 7;  // skip case 5 entirely, go straight to data
             } else {
-              client->substep = 6;
+              // Single \r\n - more headers follow, go to case 5
+              ptr1 = strncasestr(&client->buffer[pos], "\r\n", client->ptr-pos);
+              if(ptr1 != NULL) {
+		 if (((ptr1-client->buffer) + 4) >= client->ptr) {
+	  	  //CRLF on end of buffer, wait for two more to make sure we are not at end of header
+		  loop = 0;
+		 } else {
+                  client->buffer[pos++] = '=';
+                  uint16_t pos1 = (ptr1-client->buffer);
+                  uint16_t newlen = client->ptr-((pos1+2)-pos);
+                  memmove(&client->buffer[pos], &client->buffer[pos1+2], newlen);
+                  client->ptr = newlen;
+                  client->readlen += (pos1+2);
+                  client->substep = 5;
+		}
+              } else {
+		client->substep = 6;
+              }
             }
-          } else {
+    	  } else {
             loop = 0;
-          }
-        } break;
+    	  }
+	} break;
         // Content-type
         case 5: {
           unsigned char *ptr = (unsigned char *)memchr(client->buffer, '=', client->ptr);


### PR DESCRIPTION
When the Content-Type is moved before Content-Disposition the unittests fail.
I understand it should not matter in which order the headers appear. Because case 4 only worked if there is a case 5 (content-type) after it (due to not checking double CRLF) it failed.
This fixes it and skips Content-Type checking in such case but that isn't used anyways. If it must be checked, then the case structure should have a complete overhaul.